### PR TITLE
Added support for canonical package import comments in common/verdeps

### DIFF
--- a/common/verdeps/find_package_import_comment.go
+++ b/common/verdeps/find_package_import_comment.go
@@ -1,0 +1,47 @@
+package verdeps
+
+import "regexp"
+
+const (
+	importAnnotation = `import\s+(?:"[^"]*"|` + "`[^`]*`" + `)`
+	importComment    = `(?://\s*` +
+		importAnnotation +
+		`\s*$|/\*\s*` +
+		importAnnotation +
+		`\s*\*/)`
+	packageImportComment = `(?:package\s+\w+)(\s+` + importComment + `(?:.*))`
+)
+
+var packageImportCommentRegex = regexp.MustCompile(packageImportComment)
+
+// findPackageImportComment finds the indices of the package import comment if
+// one exists. If not, then it returns -1s.
+func findPackageImportComment(
+	fileData []byte,
+	packageStartIndex int,
+) (fromIndex int, toIndex int) {
+	// Read until the end of the line or the end of the file.
+	packageEndIndex := packageStartIndex
+	for packageEndIndex < len(fileData) && fileData[packageEndIndex] != '\n' {
+		packageEndIndex++
+	}
+	// Read backwards until the beginning of the file or the previous line.
+	for packageStartIndex >= 0 && fileData[packageStartIndex] != '\n' {
+		packageStartIndex--
+	}
+	// Advance the start index by one to make sure it is securely at the
+	// beginning of the line.
+	packageStartIndex++
+
+	// Find matches in [packageStartIndex, packageEndIndex).
+	line := fileData[packageStartIndex:packageEndIndex]
+	match := packageImportCommentRegex.FindSubmatchIndex(line)
+	if match != nil {
+		// Adjust the indices for the starting index of "line".
+		toIndex = packageStartIndex + match[3]
+		fromIndex = packageStartIndex + match[2]
+		return fromIndex, toIndex
+	}
+
+	return -1, -1
+}

--- a/common/verdeps/package_spec.go
+++ b/common/verdeps/package_spec.go
@@ -1,0 +1,6 @@
+package verdeps
+
+type packageSpec struct {
+	filePath   string
+	startIndex int
+}

--- a/common/verdeps/revision.go
+++ b/common/verdeps/revision.go
@@ -1,17 +1,53 @@
 package verdeps
 
-// revision represents an import in the filesystem that needs to be versioned with a gophr URL.
+// revision represents an a replacement to be made in a source file on disk.
 type revision struct {
-	path               string
-	gophrURL           []byte
-	toIndex, fromIndex int
+	path           string
+	toIndex        int
+	gophrURL       []byte
+	fromIndex      int
+	revisesImport  bool
+	revisesPackage bool
 }
 
-func newRevision(spec *importSpec, newImportPath []byte) *revision {
+func newImportRevision(spec *importSpec, newImportPath []byte) *revision {
 	return &revision{
-		path:      spec.filePath,
-		toIndex:   int(spec.imports.Path.End()),
-		gophrURL:  newImportPath,
-		fromIndex: int(spec.imports.Path.Pos()),
+		path:          spec.filePath,
+		toIndex:       int(spec.imports.Path.End()),
+		gophrURL:      newImportPath,
+		fromIndex:     int(spec.imports.Path.Pos()),
+		revisesImport: true,
 	}
+}
+
+func newPackageRevision(spec *packageSpec) *revision {
+	return &revision{
+		path:           spec.filePath,
+		fromIndex:      spec.startIndex,
+		revisesPackage: true,
+	}
+}
+
+type revisionList struct {
+	revs            []*revision
+	importRevCount  int
+	packageRevCount int
+}
+
+func newRevisionList() *revisionList {
+	return &revisionList{}
+}
+
+func (r *revisionList) add(rev *revision) {
+	if rev.revisesImport {
+		r.importRevCount = r.importRevCount + 1
+	} else if rev.revisesPackage {
+		r.packageRevCount = r.packageRevCount + 1
+	}
+
+	r.revs = append(r.revs, rev)
+}
+
+func (r *revisionList) getRevs() []*revision {
+	return r.revs
 }


### PR DESCRIPTION
Support for
```
package thing // import "github.com/a/b"
```
in `common/verdeps`. Also fixed a concurrency bug that led to race conditions on very fast machines.