### PR TITLE
fix travis to install test dep first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
 install:
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls
+- go get github.com/jinzhu/copier
 - go get ./...
 go:
 - 1.6


### PR DESCRIPTION
I think we we're missing some of our test coverage from router because of a dependency issue.