### PR TITLE
Added the concept of node ordinals

### DIFF
--- a/infra/gophrctl/module.go
+++ b/infra/gophrctl/module.go
@@ -10,15 +10,16 @@ const (
 )
 
 type module struct {
-	name         string
-	deps         []string
-	transient    bool
-	dockerfile   string
-	prodVolumes  []gCloudVolume
-	versionfile  string
-	devK8SFiles  []string
-	prodK8SFiles []string
-	buildContext string
+	name                 string
+	deps                 []string
+	transient            bool
+	dockerfile           string
+	prodVolumes          []gCloudVolume
+	versionfile          string
+	devK8SFiles          []string
+	prodK8SFiles         []string
+	buildContext         string
+	requiresNodeOrdinals bool
 }
 
 var modules = map[string]*module{
@@ -50,8 +51,9 @@ var modules = map[string]*module{
 				ssd:  true,
 			},
 		},
-		versionfile:  "./infra/docker/db/Versionfile.prod",
-		buildContext: ".",
+		versionfile:          "./infra/docker/db/Versionfile.prod",
+		buildContext:         ".",
+		requiresNodeOrdinals: true,
 	},
 	"migrator": &module{
 		name:      "migrator",

--- a/infra/k8s/db/controllers.dev.yml
+++ b/infra/k8s/db/controllers.dev.yml
@@ -14,6 +14,8 @@ spec:
         module: db
         ordinal: a
     spec:
+      nodeSelector:
+        ordinal: '1'
       containers:
         - resources:
             requests:
@@ -72,6 +74,8 @@ spec:
         module: db
         ordinal: b
     spec:
+      nodeSelector:
+        ordinal: '1'
       containers:
         - resources:
             requests:

--- a/infra/k8s/db/controllers.prod.template.yml
+++ b/infra/k8s/db/controllers.prod.template.yml
@@ -14,6 +14,8 @@ spec:
         module: db
         ordinal: a
     spec:
+      nodeSelector:
+        ordinal: '1'
       containers:
         - resources:
             requests:
@@ -74,6 +76,8 @@ spec:
         module: db
         ordinal: b
     spec:
+      nodeSelector:
+        ordinal: '2'
       containers:
         - resources:
             requests:
@@ -134,6 +138,8 @@ spec:
         module: db
         ordinal: c
     spec:
+      nodeSelector:
+        ordinal: '3'
       containers:
         - resources:
             requests:


### PR DESCRIPTION
So each node now has a unique identifier that goes from 1 - `x` where `x` is the number of nodes. This ordinals can be used by the `nodeSelector` property of K8S `PodSpecs`. The goal of these changes was to make it so that the database pods are all on different nodes.

Fixes #252 