### PR TITLE
gophrctl cmd

### DIFF
--- a/infra/gophrctl/command_cmd.go
+++ b/infra/gophrctl/command_cmd.go
@@ -1,0 +1,16 @@
+package main
+
+import "gopkg.in/urfave/cli.v1"
+
+func cmdCommand(c *cli.Context) error {
+	if err := runInK8S(c, func() error {
+		args := []string{k8sNamespaceFlag}
+		args = append(args, c.Args()...)
+
+		return execInBackground(kubectl, args...)
+	}); err != nil {
+		exit(exitCodeCMD, nil, "", err)
+	}
+
+	return nil
+}

--- a/infra/gophrctl/exec_in_background.go
+++ b/infra/gophrctl/exec_in_background.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+)
+
+func execInBackground(cmd string, args ...string) error {
+	subProcess := exec.Command(cmd, args...)
+
+	stdin, stdinErr := subProcess.StdinPipe()
+	defer stdin.Close()
+
+	subProcess.Stdout = os.Stdout
+	subProcess.Stderr = os.Stderr
+
+	startErr := subProcess.Start()
+	waitErr := subProcess.Wait()
+
+	if stdinErr != nil || startErr != nil || waitErr != nil {
+		var b bytes.Buffer
+		b.WriteString("Failed to exec \"")
+		b.WriteString(cmd)
+		for _, arg := range args {
+			b.WriteByte(' ')
+			b.WriteString(arg)
+		}
+		b.WriteString("\" due to some errors along the way: [ ")
+		if stdinErr != nil {
+			b.WriteString(stdinErr.Error())
+			b.WriteString(", ")
+		}
+		if startErr != nil {
+			b.WriteString(startErr.Error())
+			b.WriteString(", ")
+		}
+		if waitErr != nil {
+			b.WriteString(waitErr.Error())
+		}
+		b.WriteString(" ].")
+
+		return errors.New(b.String())
+	}
+
+	return nil
+}

--- a/infra/gophrctl/exit.go
+++ b/infra/gophrctl/exit.go
@@ -21,6 +21,7 @@ const (
 	exitCodePodsFailed         = 110
 	exitCodeUpFailed           = 111
 	exitCodeRevealSecretFailed = 112
+	exitCodeCMD                = 113
 )
 
 func exit(

--- a/infra/gophrctl/main.go
+++ b/infra/gophrctl/main.go
@@ -47,6 +47,8 @@ const (
 	commandDescBuild              = "Updates module images"
 	commandNameCycle              = "cycle"
 	commandDescCycle              = "Re-creates a module in kubernetes"
+	commandNameCMD                = "cmd"
+	commandDescCMD                = "Executes a manually specified kubectl command"
 	commandNameLog                = "log"
 	commandDescLog                = "Logs module's container output to stdout"
 	commandNamePods               = "pods"
@@ -76,6 +78,7 @@ const (
 )
 
 var (
+	cmdCommandArgsUsage    = "[kubectl command] [kubectl command arguments...]"
 	moduleCommandArgsUsage = fmt.Sprintf("[%s] [arguments...]", modulesToString())
 )
 
@@ -139,6 +142,15 @@ func main() {
 					EnvVar: envVarGPI,
 				},
 			},
+		},
+
+		// CMD command.
+		{
+			Name:            commandNameCMD,
+			Usage:           commandDescCMD,
+			Action:          cmdCommand,
+			ArgsUsage:       cmdCommandArgsUsage,
+			SkipFlagParsing: true,
 		},
 
 		// Cycle command.


### PR DESCRIPTION
```sh
gophrctl [--prod] cmd [kubectl command]
```
Allows the execution of kubectl commands via `gophrctl`. For example, to show the nodes in the cluster in production:  
```sh
gophrctl --prod cmd get nodes --show-labels
```